### PR TITLE
Mtac2 - Mmatching matches

### DIFF
--- a/plugins/mtac2/Mtac2.v
+++ b/plugins/mtac2/Mtac2.v
@@ -6,6 +6,17 @@ Inductive Exception : Type := exception : Exception.
 
 Parameter LazyList : Type -> Type.
 
+Inductive dyn := Dyn { dynt : Type; elem : dynt }.
+
+Record Case :=
+    mkCase {
+        case_ind : Type;
+        case_val : case_ind;
+        case_type : Type;
+        case_return : dyn;
+        case_branches : list dyn
+        }.
+
 Inductive goal : Type := opaque : forall {A : Type}, goal.
 
 (* Assumption: when one has [Named patt name], [name] comes from a [Mtele] (see
@@ -54,6 +65,9 @@ Inductive Mtac2 : Type -> Prop :=
 | Mgmatch : forall {A} (g:goal), list (Mpatt goal (fun g => A) g) -> Mtac2 A
 | Mnext : forall {A:Type}, LazyList A -> Mtac2 (option (A * LazyList A))
 | Mshow : goal -> Mtac2 unit
+| Mdestcase : forall {A} (a : A), Mtac2 (Case)
+| Mconstrs : forall {A : Type} (a : A), Mtac2 (list dyn)
+| Mmakecase : forall (C : Case), Mtac2 dyn
 
 with Mpatt : forall A (B : A -> Type) (t : A), Type := 
 | Mbase : forall {A B t} (x:A) (b : t = x -> Mtac2 (B x)), Mpatt A B t

--- a/plugins/mtac2/run.ml
+++ b/plugins/mtac2/run.ml
@@ -657,42 +657,21 @@ let get_Constrs (env, sigma) t =
     match Term.kind_of_term t_type with
     | Term.Ind (mind, ind_i) -> 
       let mbody = Environ.lookup_mind mind env in
-      Pp.pperr (Pp.str "lookup OK\n");
-      Pp.flush_all ();
       let ind = Array.get (mbody.mind_packets) ind_i in
-      Pp.pperr (Pp.str "packets OK\n");
-      Pp.flush_all ();
       let dyn = MtacNames.mkConstr "dyn" in
       let mkDyn = MtacNames.mkConstr "Dyn" in
-      Pp.pperr (Pp.str "defs OK\n");
-      Pp.flush_all ();
       let l = Array.fold_left 
           (fun l i ->
               let constr = Names.ith_constructor_of_inductive (mind, ind_i) i in
-              Pp.pperr (Pp.str "ith constr OK\n");
-              Pp.pperr (Pp.int i);
-              Pp.pperr (Pp.str "\n");
-              Pp.flush_all ();
               let coq_constr = Term.applist (mkDyn, [CoqList.makeNil dyn]) in
               let coq_constr = Term.mkConstruct constr in
               let dyn_constr = Term.applist (mkDyn, [coq_constr]) in
-              Pp.pperr (Pp.str "applist OK\n");
-              Pp.flush_all ();
               CoqList.makeCons dyn dyn_constr l 
           )
-              (let x = 
-          CoqList.makeNil dyn in
-             Pp.pperr (Pp.str "nil OK\n");
-              Pp.flush_all (); x )  
+              (CoqList.makeNil dyn )  
           (* this is just a dirty hack to get the indices of constructors *)
-          (let x = Array.mapi (fun i t -> i+1) ind.mind_consnames in 
-              Pp.pperr (Pp.str "mapi OK\n");
-              Pp.flush_all (); x
-          )
-
+          (Array.mapi (fun i t -> i+1) ind.mind_consnames)
       in  
-      Pp.pperr (Pp.str "everything OK\n");
-              Pp.flush_all () ;
       (sigma, l)
   else
     Exceptions.block "The argument of Mconstrs is not an inductive type"


### PR DESCRIPTION
UPDATE: Pull request now fixed. It's all Github's fault, I swear!

This patch adds 3 new constructors to the Mtac2 datatype:
1. Mdestcase : forall {A} (a : A), Mtac2 Case
2. Mconstrs : forall {A : Type} (a : A), Mtac2 (list dyn)
3. Mmakecase : forall (C : Case), Mtac2 dyn
where dyn are dynamic values and Case is a weakly-typed record representing a Coq match.

Mconstrs returns the list of constructors for a datatype. The type signature seems weird on first glance, but we need to account for parametrized and indexed datatypes, so our argument won't be of type Type, but rather of some type .... -> Type.

Mdestcase and Mmakecase are very straightforward: the former one takes a value (hopefully a match) and constructs an equivalent Case record (if possible). The latter reverts the process, but returns a dynamic value. (We forget some types on the way, so for now this is all we can do).
